### PR TITLE
chore: bump wrangler compatibility_date

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -2,7 +2,7 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "weft-dev",
   "main": "worker/index.ts",
-  "compatibility_date": "2025-12-10",
+  "compatibility_date": "2026-01-12",
   "workers_dev": true,
   "preview_urls": false,
   "compatibility_flags": ["nodejs_compat_v2"],


### PR DESCRIPTION
Hey @jonesphillip 👋

This PR updates the `compatibility_date` in `wrangler.jsonc` to `2026-01-12`.

Keeping this value current ensures access to the latest Workers runtime features and bug fixes.

See: https://developers.cloudflare.com/workers/configuration/compatibility-dates/